### PR TITLE
Use stable ids for budget entries

### DIFF
--- a/budget.js
+++ b/budget.js
@@ -129,7 +129,7 @@ allList.addEventListener("click", deleteOrEdit);
 // HELPER FUNCTIONS
 function deleteOrEdit(event) {
   const targetBtn = event.target;
-  const entry = targetBtn.parentNode;
+  const entry = targetBtn.closest("li");
 
   if (targetBtn.id == EDIT) {
     editEntry(entry);
@@ -139,12 +139,13 @@ function deleteOrEdit(event) {
 }
 
 function deleteEntry(entry) {
-  ENTRY_LIST = logic.removeEntryAt(ENTRY_LIST, entry.id);
+  ENTRY_LIST = logic.removeEntryById(ENTRY_LIST, entry.dataset.entryId);
   updateUI();
 }
 
 function editEntry(entry) {
-  const ENTRY = ENTRY_LIST[entry.id];
+  const ENTRY = logic.findEntryById(ENTRY_LIST, entry.dataset.entryId);
+  if (!ENTRY) return;
 
   if (ENTRY.type == "income") {
     incomeTitle.value = ENTRY.title;
@@ -169,21 +170,21 @@ function updateUI() {
 
   clearElement([expenseList, incomeList, allList]);
 
-  ENTRY_LIST.forEach((entry, index) => {
+  ENTRY_LIST.forEach((entry) => {
     if (entry.type == "expense") {
-      showEntry(expenseList, entry.type, entry.title, entry.amount, index);
+      showEntry(expenseList, entry);
     } else if (entry.type == "income") {
-      showEntry(incomeList, entry.type, entry.title, entry.amount, index);
+      showEntry(incomeList, entry);
     }
-    showEntry(allList, entry.type, entry.title, entry.amount, index);
+    showEntry(allList, entry);
   });
   updateChart(income, outcome);
   logic.saveEntries(localStorage, ENTRY_LIST);
 }
 
-function showEntry(list, type, title, amount, id) {
-  const entry = `<li id="${id}" class="${type}">
-                    <div class="entry">${title} : $${amount}</div>
+function showEntry(list, budgetEntry) {
+  const entry = `<li data-entry-id="${budgetEntry.id}" class="${budgetEntry.type}">
+                    <div class="entry">${budgetEntry.title} : $${budgetEntry.amount}</div>
                     <div id="edit"></div>
                     <div id="delete"></div>
                   </li>`;

--- a/budgetLogic.js
+++ b/budgetLogic.js
@@ -7,12 +7,25 @@
 })(typeof self !== "undefined" ? self : this, function () {
   const ENTRY_STORAGE_KEY = "entry_list";
 
+  function generateEntryId() {
+    return `entry-${Date.now().toString(36)}-${Math.random()
+      .toString(36)
+      .slice(2, 10)}`;
+  }
+
+  function ensureEntryId(entry) {
+    return {
+      ...entry,
+      id: entry.id || generateEntryId(),
+    };
+  }
+
   function parseEntries(rawValue) {
     if (!rawValue) return [];
 
     try {
       const parsed = JSON.parse(rawValue);
-      return Array.isArray(parsed) ? parsed : [];
+      return Array.isArray(parsed) ? parsed.map(ensureEntryId) : [];
     } catch (error) {
       return [];
     }
@@ -26,8 +39,9 @@
     storage.setItem(ENTRY_STORAGE_KEY, JSON.stringify(entries));
   }
 
-  function createEntry(type, title, amount) {
+  function createEntry(type, title, amount, id = generateEntryId()) {
     return {
+      id,
       type,
       title,
       amount: Number(amount),
@@ -42,8 +56,12 @@
     return [...entries, entry];
   }
 
-  function removeEntryAt(entries, index) {
-    return entries.filter((entry, entryIndex) => entryIndex !== Number(index));
+  function findEntryById(entries, id) {
+    return entries.find((entry) => String(entry.id) === String(id));
+  }
+
+  function removeEntryById(entries, id) {
+    return entries.filter((entry) => String(entry.id) !== String(id));
   }
 
   function calculateTotal(type, entries) {
@@ -75,11 +93,12 @@
     calculateBalance,
     calculateTotal,
     createEntry,
+    findEntryById,
     getBudgetSummary,
     hasRequiredEntryFields,
     loadEntries,
     parseEntries,
-    removeEntryAt,
+    removeEntryById,
     saveEntries,
   };
 });

--- a/budgetLogic.test.js
+++ b/budgetLogic.test.js
@@ -8,11 +8,19 @@ describe("budget logic", () => {
   });
 
   test("createEntry normalizes amount values to numbers", () => {
-    expect(BudgetLogic.createEntry("income", "Salary", "1200")).toEqual({
+    expect(BudgetLogic.createEntry("income", "Salary", "1200", "entry-1")).toEqual({
+      id: "entry-1",
       type: "income",
       title: "Salary",
       amount: 1200,
     });
+  });
+
+  test("createEntry assigns a stable id when one is not provided", () => {
+    const entry = BudgetLogic.createEntry("income", "Salary", "1200");
+
+    expect(entry.id).toEqual(expect.any(String));
+    expect(entry.id).not.toHaveLength(0);
   });
 
   test("hasRequiredEntryFields preserves the original required-field behavior", () => {
@@ -22,8 +30,8 @@ describe("budget logic", () => {
   });
 
   test("addEntry returns a new entries list without mutating the original list", () => {
-    const entries = [BudgetLogic.createEntry("income", "Salary", 1000)];
-    const expense = BudgetLogic.createEntry("expense", "Food", 80);
+    const entries = [BudgetLogic.createEntry("income", "Salary", 1000, "entry-1")];
+    const expense = BudgetLogic.createEntry("expense", "Food", 80, "entry-2");
 
     const nextEntries = BudgetLogic.addEntry(entries, expense);
 
@@ -31,27 +39,36 @@ describe("budget logic", () => {
     expect(entries).toHaveLength(1);
   });
 
-  test("removeEntryAt removes the requested entry without mutating the original list", () => {
+  test("removeEntryById removes the requested entry without mutating the original list", () => {
     const entries = [
-      BudgetLogic.createEntry("income", "Salary", 1000),
-      BudgetLogic.createEntry("expense", "Food", 80),
-      BudgetLogic.createEntry("expense", "Transport", 20),
+      BudgetLogic.createEntry("income", "Salary", 1000, "entry-1"),
+      BudgetLogic.createEntry("expense", "Food", 80, "entry-2"),
+      BudgetLogic.createEntry("expense", "Transport", 20, "entry-3"),
     ];
 
-    const nextEntries = BudgetLogic.removeEntryAt(entries, 1);
+    const nextEntries = BudgetLogic.removeEntryById(entries, "entry-2");
 
     expect(nextEntries).toEqual([
-      BudgetLogic.createEntry("income", "Salary", 1000),
-      BudgetLogic.createEntry("expense", "Transport", 20),
+      BudgetLogic.createEntry("income", "Salary", 1000, "entry-1"),
+      BudgetLogic.createEntry("expense", "Transport", 20, "entry-3"),
     ]);
     expect(entries).toHaveLength(3);
   });
 
+  test("findEntryById returns the matching entry", () => {
+    const entries = [
+      BudgetLogic.createEntry("income", "Salary", 1000, "entry-1"),
+      BudgetLogic.createEntry("expense", "Food", 80, "entry-2"),
+    ];
+
+    expect(BudgetLogic.findEntryById(entries, "entry-2")).toEqual(entries[1]);
+  });
+
   test("calculateTotal sums entries by type", () => {
     const entries = [
-      BudgetLogic.createEntry("income", "Salary", 1000),
-      BudgetLogic.createEntry("income", "Gift", 50),
-      BudgetLogic.createEntry("expense", "Food", 80),
+      BudgetLogic.createEntry("income", "Salary", 1000, "entry-1"),
+      BudgetLogic.createEntry("income", "Gift", 50, "entry-2"),
+      BudgetLogic.createEntry("expense", "Food", 80, "entry-3"),
     ];
 
     expect(BudgetLogic.calculateTotal("income", entries)).toBe(1050);
@@ -65,9 +82,9 @@ describe("budget logic", () => {
 
   test("getBudgetSummary returns totals, absolute balance, and display sign", () => {
     const entries = [
-      BudgetLogic.createEntry("income", "Salary", 1000),
-      BudgetLogic.createEntry("expense", "Food", 80),
-      BudgetLogic.createEntry("expense", "Rent", 1200),
+      BudgetLogic.createEntry("income", "Salary", 1000, "entry-1"),
+      BudgetLogic.createEntry("expense", "Food", 80, "entry-2"),
+      BudgetLogic.createEntry("expense", "Rent", 1200, "entry-3"),
     ];
 
     expect(BudgetLogic.getBudgetSummary(entries)).toEqual({
@@ -86,11 +103,27 @@ describe("budget logic", () => {
         storage.value = value;
       }),
     };
-    const entries = [BudgetLogic.createEntry("income", "Salary", 1000)];
+    const entries = [BudgetLogic.createEntry("income", "Salary", 1000, "entry-1")];
 
     BudgetLogic.saveEntries(storage, entries);
 
     expect(storage.setItem).toHaveBeenCalledWith("entry_list", JSON.stringify(entries));
     expect(BudgetLogic.loadEntries(storage)).toEqual(entries);
+  });
+
+  test("loadEntries adds ids to legacy entries without ids", () => {
+    const storage = {
+      getItem: jest.fn(() => JSON.stringify([{ type: "income", title: "Salary", amount: 1000 }])),
+    };
+
+    const entries = BudgetLogic.loadEntries(storage);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      type: "income",
+      title: "Salary",
+      amount: 1000,
+    });
+    expect(entries[0].id).toEqual(expect.any(String));
   });
 });


### PR DESCRIPTION
## Summary

This PR updates budget entries to use stable unique IDs instead of relying on array indexes for edit and delete operations.

## Changes

- Add a stable `id` to each newly created budget entry.
- Store the entry ID in the DOM using `data-entry-id` instead of using the array index as the element ID.
- Update edit logic to find entries by ID.
- Update delete logic to remove entries by ID.
- Add compatibility for legacy entries loaded from `localStorage` that do not already have an ID.
- Update unit tests for ID-based entry handling.

## Testing

- Ran `npm test -- --runInBand`
- Result: all tests passed, `12 passed`
