### PR TITLE
Handle zero-total chart rendering edge case

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -34,7 +34,13 @@ function drawCircle(color, ratio, anticlockwise) {
 function updateChart(income, outcome) {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  let ratio = income / (outcome + income);
+  const total = income + outcome;
+
+  if (total === 0) {
+    return;
+  }
+
+  let ratio = income / total;
 
   drawCircle("#FFF", -ratio, true);
   drawCircle("#F0624D", 1 - ratio, false);


### PR DESCRIPTION
## Summary
- Clear the chart canvas and return early when income and outcome total zero
- Avoid calculating a NaN ratio for the initial empty state or after all entries are removed

Closes #6

## Testing
- /Applications/Codex.app/Contents/Resources/node --check chart.js
- git diff --check
